### PR TITLE
Fix erroneous behavior if removable does not exist in the items array.

### DIFF
--- a/arrays/spread/slice.js
+++ b/arrays/spread/slice.js
@@ -2,8 +2,11 @@
 
 //  # START:removeItemSlice
 function removeItem(items, removable) {
-  const index = items.indexOf(removable);
-  return items.slice(0, index).concat(items.slice(index + 1));
+  if (items.includes(removable)) {
+    const index = items.indexOf(removable);
+    return items.slice(0, index).concat(items.slice(index + 1));
+  }
+  return items;
 }
 //  # END:removeItemSlice
 

--- a/arrays/spread/splice.js
+++ b/arrays/spread/splice.js
@@ -1,8 +1,10 @@
 /* eslint-disable no-unused-vars */
 //  # START:removeItemSplice
 function removeItem(items, removable) {
-  const index = items.indexOf(removable);
-  items.splice(index, 1);
+  if (items.includes(removable)) {
+    const index = items.indexOf(removable);
+    items.splice(index, 1);
+  }
   return items;
 }
 //  # END:removeItemSplice

--- a/arrays/spread/spread.js
+++ b/arrays/spread/spread.js
@@ -2,8 +2,11 @@
 
 //  # START:removeItemSpread
 function removeItem(items, removable) {
-  const index = items.indexOf(removable);
-  return [...items.slice(0, index), ...items.slice(index + 1)];
+  if (items.includes(removable)) {
+    const index = items.indexOf(removable);
+    return [...items.slice(0, index), ...items.slice(index + 1)];
+  }
+  return items;
 }
 //  # END:removeItemSpread
 

--- a/arrays/spread/spread.spec.js
+++ b/arrays/spread/spread.spec.js
@@ -53,4 +53,28 @@ describe('spread operator', () => {
     expect(formatBook(...values)).toEqual('Reasons and Persons by Derek Parfit $19.99');
     expect(formatBook(...Object.values(book))).toEqual('Reasons and Persons by Derek Parfit $19.99');
   });
+
+  it('should not modify with a loop', () => {
+    const before = ['apple', 'banana', 'orange'];
+    const after = ['apple', 'banana', 'orange'];
+    expect(removeItemProblem(before, 'peach')).toEqual(after);
+  });
+
+  it('should not modify with a slice', () => {
+    const before = ['apple', 'banana', 'orange'];
+    const after = ['apple', 'banana', 'orange'];
+    expect(removeItemSlice(before, 'peach')).toEqual(after);
+  });
+
+  it('should not modify with a splice', () => {
+    const before = ['apple', 'banana', 'orange'];
+    const after = ['apple', 'banana', 'orange'];
+    expect(removeItemSplice(before, 'peach')).toEqual(after);
+  });
+
+  it('should not modify with a spread', () => {
+    const before = ['apple', 'banana', 'orange'];
+    const after = ['apple', 'banana', 'orange'];
+    expect(removeItem(before, 'peach')).toEqual(after);
+  });
 });


### PR DESCRIPTION
Can you determine the erroneous output just by looking at the code for each case, splice, slice, and spread?  Hint, the spread operator does not look like the others.

I debated about creating this pull request.  I realize, from a teaching perspective, just putting enough relevant code to teach a point is certainly acceptable and possibly preferred.  Adding extra code to make the example more resilient to errors can make the specific teaching point harder to see.

So why the pull request?

Perfect opportunity to use more resilient code example with minimal intrusiveness to current concepts, while simultaneously building upon and/or reinforcing previous concepts.

Tip #6 sole purpose was to highlight the new ES2017 includes() method.  To add more usage of it in Tip #7 can help the reader get used to seeing ‘includes’ moving forward, and continued illustration of just how useful it is.
